### PR TITLE
uploader: handle X-Clickhouse-Exception-Code header

### DIFF
--- a/uploader/base.go
+++ b/uploader/base.go
@@ -258,6 +258,10 @@ func (u *Base) insertRowBinary(table string, data io.Reader) error {
 
 	body, _ := ioutil.ReadAll(resp.Body)
 
+	if exceptionCode := resp.Header.Get("X-Clickhouse-Exception-Code"); exceptionCode != "" && exceptionCode != "0" {
+		return fmt.Errorf("clickhouse exception code %s, response status %d: %s", exceptionCode, resp.StatusCode, string(body))
+	}
+
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("clickhouse response status %d: %s", resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Hi,

we noticed that in case of an error ClickHouse sometimes can return a status code 200 with an actual error in `X-Clickhouse-Exception-Code` header. This PR adds failing upload when this header is present in the response.

We sometimes observed that happening after a timeout error on ClickHouse end. In the response there was a status code 200 and a 209 code in `X-ClickHouse-Exception-Code` (['socket timeout'](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp#L177)). It caused a sporadic metric loss as ClickHouse didn't read the whole body and carbon-clickhouse considered the upload to be successful.

I've also found a similar issue created for ClickHouse tests - https://github.com/ClickHouse/ClickHouse/issues/44885.