### PR TITLE
feat(config): add -exact-config command line argument

### DIFF
--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -47,6 +47,7 @@ func main() {
 	configFile := flag.String("config", "/etc/carbon-clickhouse/carbon-clickhouse.conf", "Filename of config")
 	printDefaultConfig := flag.Bool("config-print-default", false, "Print default config")
 	checkConfig := flag.Bool("check-config", false, "Check config and exit")
+	exactConfig := flag.Bool("exact-config", false, "Ensure that all config params are contained in the target struct.")
 	printVersion := flag.Bool("version", false, "Print version")
 	cat := flag.String("cat", "", "Print RowBinary file in TabSeparated format")
 	bincat := flag.String("recover", "", "Read all good records from corrupted data file. Write binary data to stdout")
@@ -102,7 +103,7 @@ func main() {
 
 	app := carbon.New(*configFile)
 
-	if err = app.ParseConfig(); err != nil {
+	if err = app.ParseConfig(*exactConfig); err != nil {
 		log.Fatal(err)
 	}
 

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -47,8 +47,8 @@ func New(configFilename string) *App {
 }
 
 // configure loads config from config file, schemas.conf, aggregation.conf
-func (app *App) configure() error {
-	cfg, err := ReadConfig(app.ConfigFilename)
+func (app *App) configure(exactConfig bool) error {
+	cfg, err := ReadConfig(app.ConfigFilename, exactConfig)
 	if err != nil {
 		return err
 	}
@@ -88,11 +88,11 @@ func (app *App) configure() error {
 }
 
 // ParseConfig loads config from config file
-func (app *App) ParseConfig() error {
+func (app *App) ParseConfig(exactConfig bool) error {
 	app.Lock()
 	defer app.Unlock()
 
-	return app.configure()
+	return app.configure(exactConfig)
 }
 
 // Stop all socket listeners

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -250,7 +250,7 @@ func PrintDefaultConfig() error {
 }
 
 // ReadConfig ...
-func ReadConfig(filename string) (*Config, error) {
+func ReadConfig(filename string, exactConfig bool) (*Config, error) {
 	var err error
 
 	cfg := NewConfig()
@@ -265,8 +265,17 @@ func ReadConfig(filename string) (*Config, error) {
 		// @TODO: fix for config starts with [logging]
 		body = strings.Replace(body, "\n[logging]\n", "\n[[logging]]\n", -1)
 
-		if _, err := toml.Decode(body, cfg); err != nil {
+		md, err := toml.Decode(body, cfg)
+
+		if err != nil {
 			return nil, err
+		}
+
+		if exactConfig {
+			undecoded := md.Undecoded()
+			if len(undecoded) > 0 {
+				return nil, fmt.Errorf("Config file (%s) contains unknown keys: %q", filename, undecoded)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds the "-exact-config" command line argument which ensures that all parameters in a config file are contained inside the corresponding struct.