### PR TITLE
e2e tests: add e2e tests binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
-carbon-clickhouse
+
+/carbon-clickhouse
+/e2e-test
 
 *.exe
 *.test

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ all: $(NAME)
 .PHONY: clean
 clean:
 	rm -f $(NAME)
+	rm -f e2e-test
 	rm -rf out
 	rm -f *deb *rpm
 	rm -f sha256sum md5sum


### PR DESCRIPTION
Hi!

I noticed that e2e-test binary is committed in the repository. I believe it was added by accident so here I remove it and add to .gitignore (so it doesn't appear as changed if somebody runs e2e tests on their machines).

And thanks for merging other two PRs :)