### PR TITLE
Bump actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1
 
@@ -56,7 +56,7 @@ jobs:
 
     - name: Artifact
       id: artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         retention-days: 1
@@ -78,7 +78,7 @@ jobs:
       matrix: ${{fromJson(needs.build.outputs.matrix)}}
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: packages
     - name: Upload ${{ matrix.file }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -113,7 +113,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -121,7 +121,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1
 


### PR DESCRIPTION
setup-go: v2 -> v5
upload-artifact: v2 -> v4
download-artifact: v2 -> v4