### PR TITLE
Fix gox installation in release workflow and update setup-go to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1
 
@@ -36,7 +36,7 @@ jobs:
     - name: Install packaging dependencies
       run: |
         gem install fpm package_cloud
-        GO111MODULE=off go get github.com/mitchellh/gox
+        cd && go install github.com/mitchellh/gox@latest
 
     - name: Build packages
       id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install packaging dependencies
       run: |
         gem install fpm package_cloud
-        cd && go install github.com/mitchellh/gox@latest
+        cd && go install github.com/mitchellh/gox@v1.0.1
 
     - name: Build packages
       id: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -113,7 +113,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -121,7 +121,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1
 


### PR DESCRIPTION
Fixes the following error [here](https://github.com/go-graphite/carbon-clickhouse/actions/runs/10830113210/job/30049134384): `go: modules disabled by GO111MODULE=off; see 'go help modules'`
Also bumps setup-go to v5 again