### PR TITLE
Fix #135

### DIFF
--- a/helper/escape/url.go
+++ b/helper/escape/url.go
@@ -182,7 +182,7 @@ func escapeTo(s string, mode encoding, sb *stringutils.Builder) {
 	if pos == 0 {
 		sb.WriteString(s)
 		return
-	} else if pos < len(s)-1 {
+	} else if pos < len(s) {
 		sb.WriteString(s[pos:])
 	}
 }

--- a/tests/plain/test.toml
+++ b/tests/plain/test.toml
@@ -89,7 +89,7 @@ input = [
     "cpu.loadavg;env=test;host=host1 2.1 1625478240",
     "test.host1.cpu.loadavg 9.4 1625478300",
     "cpu.loadavg;host=host1;env=test 1.3 1625478360",
-    "spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward=/a 5.1 1625478360",
+    "spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward/0=/0 5.1 1625478360",
     "non-ascii.иван;tagged=true 1.2 1625478240"
 ]
 
@@ -154,7 +154,7 @@ output = [
     "cpu.loadavg?env=test&host=host1 1.3 1625478360 2021-07-05 0",
 ]
 
-# Tests for issue #116
+# Tests for issues: #116 #135
 # spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward/0=/0 5.1 1625478360
 [[test.verify]]
 query = "SELECT Date, Tag1, Path, arraySort(Tags) as Tags FROM graphite_tags WHERE Path LIKE 'spec_symbols?%' ORDER BY Date, Tag1, Path"

--- a/tests/plain/test.toml
+++ b/tests/plain/test.toml
@@ -89,7 +89,7 @@ input = [
     "cpu.loadavg;env=test;host=host1 2.1 1625478240",
     "test.host1.cpu.loadavg 9.4 1625478300",
     "cpu.loadavg;host=host1;env=test 1.3 1625478360",
-    "spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward=/ 5.1 1625478360",
+    "spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward=/a 5.1 1625478360",
     "non-ascii.иван;tagged=true 1.2 1625478240"
 ]
 
@@ -155,23 +155,23 @@ output = [
 ]
 
 # Tests for issue #116
-# spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward=/ 5.1 1625478360
+# spec_symbols;minus=-;plus=+;percent=%;underscore=_;colon=:;hash=#;forward/0=/0 5.1 1625478360
 [[test.verify]]
 query = "SELECT Date, Tag1, Path, arraySort(Tags) as Tags FROM graphite_tags WHERE Path LIKE 'spec_symbols?%' ORDER BY Date, Tag1, Path"
 output = [
-    "2021-07-05 __name__=spec_symbols spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 colon=: spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 forward=/ spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 hash=# spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 minus=- spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 percent=% spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 plus=+ spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']",
-    "2021-07-05 underscore=_ spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward=/','hash=#','minus=-','percent=%','plus=+','underscore=_']"
+    "2021-07-05 __name__=spec_symbols spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 colon=: spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 forward/0=/0 spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 hash=# spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 minus=- spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 percent=% spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 plus=+ spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']",
+    "2021-07-05 underscore=_ spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ ['__name__=spec_symbols','colon=:','forward/0=/0','hash=#','minus=-','percent=%','plus=+','underscore=_']"
 ]
 [[test.verify]]
 query = "SELECT Path, Value, Time, Date, Timestamp FROM graphite WHERE Path LIKE 'spec_symbols?%' ORDER BY Time, Path"
 output = [
-    "spec_symbols?colon=%3A&forward=%2F&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ 5.1 1625478360 2021-07-05 0"
+    "spec_symbols?colon=%3A&forward%2F0=%2F0&hash=%23&minus=-&percent=%25&plus=%2B&underscore=_ 5.1 1625478360 2021-07-05 0"
 ]
 
 # Tests for non-ASCII symbols in path


### PR DESCRIPTION
The last printable character gets lost if it is preceded by special symbol.
```
# echo "spec_symbols?0;forward/0=/0 0 $(date +%s)" | nc 127.0.0.1 2013

   ┌───────Date─┬─Tag1───────────────────┬─Path───────────────────────────┬─Tags────────────────────────────────────┬────Version─┐
1. │ 2024-11-27 │ __name__=spec_symbols? │ spec_symbols%3F?forward%2F=%2F │ ['__name__=spec_symbols?','forward/=/'] │ 1732698535 │
2. │ 2024-11-27 │ forward/=/             │ spec_symbols%3F?forward%2F=%2F │ ['__name__=spec_symbols?','forward/=/'] │ 1732698535 │
   └────────────┴────────────────────────┴────────────────────────────────┴─────────────────────────────────────────┴────────────┘
```