### PR TITLE
fix(e2e-test): bypass default user having disabled network access in latest ch versions

### DIFF
--- a/cmd/e2e-test/clickhouse.go
+++ b/cmd/e2e-test/clickhouse.go
@@ -84,6 +84,7 @@ func (c *Clickhouse) Start() (string, error) {
 		"--name", c.container,
 		"--ulimit", "nofile=262144:262144",
 		"-p", port + ":8123",
+		"-e", "CLICKHOUSE_SKIP_USER_SETUP=1",
 		// "-e", "TZ=" + tz, // workaround for TZ=":/etc/localtime"
 		"-v", c.Dir + "/config.xml:/etc/clickhouse-server/config.xml",
 		"-v", c.Dir + "/users.xml:/etc/clickhouse-server/users.xml",


### PR DESCRIPTION
Tests with 'latest' clickhouse version started to fail because of https://github.com/ClickHouse/ClickHouse/pull/75259.

Use env variable `CLICKHOUSE_SKIP_USER_SETUP=1` when starting clickhouse container during e2e-tests to avoid it.
https://github.com/ClickHouse/ClickHouse/issues/75494#issuecomment-2634536752.